### PR TITLE
Fix position in a slide modal

### DIFF
--- a/src/RLDDItemComponent.tsx
+++ b/src/RLDDItemComponent.tsx
@@ -95,8 +95,8 @@ export default class RLDDItemComponent extends React.Component<RLDDItemProps, RL
     }
 
     const offset = {
-      x: e.pageX - this.initialOffset.x,
-      y: e.pageY - this.initialOffset.y
+      x: e.layerX - this.initialOffset.x,
+      y: e.layerY - this.initialOffset.y
     };
 
     if (this.state.isDragging === false && this.isDown) {


### PR DESCRIPTION
if you have a slide modal animated, the position of event click doesn't fit