### PR TITLE
Fix floating component position glitching for all sub components

### DIFF
--- a/src/RLDDFloatingItem.css
+++ b/src/RLDDFloatingItem.css
@@ -1,3 +1,3 @@
-.dl-item.activity > div {
+.dl-item.activity > * {
   pointer-events: none;
 }


### PR DESCRIPTION
The previous logic applies only to div tags, now it will be applied for all tags.